### PR TITLE
Fix URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   ],
   "description": "Access a Piwik API from node.js",
   "version": "0.2.0",
-  "homepage": "https://github.com/sandfox/aws-arn-parser",
-  "bugs": "https://github.com/sandfox/aws-arn-parser/issues",
+  "homepage": "https://github.com/sandfox/nodejs-piwik",
+  "bugs": "https://github.com/sandfox/nodejs-piwik/issues",
   "repository": {
     "type": "git",
     "url": "git://github.com/sandfox/nodejs-piwik.git"


### PR DESCRIPTION
Fixed old URLs. Issues are not working since they are not activated for your repository (activate maybe?) - otherwise the line should be removed.
